### PR TITLE
Only add a question-mark query identifier if there is not one already

### DIFF
--- a/app/views/named_routes/generate.js.erb
+++ b/app/views/named_routes/generate.js.erb
@@ -27,7 +27,7 @@ var <%= scope %> = {
 
   var query="";
   if (extras) {
-    query += "?"
+    query += segments[segments.length - 1] === "?" ?  "" :  "?";
     for (var extra in extras) {
       query += extra + "=" + extras[extra] + "&";
     }


### PR DESCRIPTION
Getting and extra "?" when trying to pass options to the function, so this tests to see if the URL already ends with a "?" and if so, does not add another. 

CMS still works :dancers: 
